### PR TITLE
Implement an `exit` command

### DIFF
--- a/Payload_Type/venus/mythic/agent_functions/exit.py
+++ b/Payload_Type/venus/mythic/agent_functions/exit.py
@@ -1,0 +1,32 @@
+from CommandBase import *
+import json
+
+class ExitArguments(TaskArguments):
+    def __init__(self, command_line):
+        super().__init__(command_line)
+        self.args = {}
+
+    async def parse_arguments(self):
+        pass
+
+class ExitCommand(CommandBase):
+    cmd = "exit"
+    needs_admin = False
+    help_cmd = "exit"
+    description = "Exit the extension on next interval (does not uninstall)"
+    version = 1
+    is_exit = True
+    is_file_browse = False
+    is_process_list = False
+    is_download_file = False
+    is_remove_file = False
+    is_upload_file = False
+    author = "@mattreduce"
+    attackmapping = []
+    argument_class = ExitArguments
+
+    async def create_tasking(self, task: MythicTask) -> MythicTask:
+        return task
+
+    async def process_response(self, response: AgentResponse):
+        pass


### PR DESCRIPTION
* Not processed until next callback interval
* Does not permanently uninstall
* Gives no indication to the user that something has changed
* Also updates `setInterval()` to call a new `mainLoop()` function instead of `getTasking()`, paving the way for other things to occur there on interval (like exiting if the kill date has passed)

Closes #8